### PR TITLE
infra: update Checkstyle config to use 'accessModifiers' in JavadocMethodCheck

### DIFF
--- a/src/main/resources/net/sourceforge/pmd/pmd-checkstyle-config.xml
+++ b/src/main/resources/net/sourceforge/pmd/pmd-checkstyle-config.xml
@@ -25,7 +25,7 @@
     </module>
     <module name="JavadocMethod">
       <property name="severity" value="warning"/>
-      <property name="scope" value="protected"/>
+      <property name="accessModifiers" value="public,protected"/>
     </module>
     <module name="JavadocStyle">
       <property name="severity" value="warning"/>


### PR DESCRIPTION
related to https://github.com/checkstyle/checkstyle/issues/7417