### PR TITLE
from scope to accessModifiers in JavadocVariable

### DIFF
--- a/src/main/resources/net/sourceforge/pmd/pmd-checkstyle-config.xml
+++ b/src/main/resources/net/sourceforge/pmd/pmd-checkstyle-config.xml
@@ -38,7 +38,7 @@
     </module>
     <module name="JavadocVariable">
       <property name="severity" value="warning"/>
-      <property name="scope" value="protected"/>
+      <property name="accessModifiers" value="public,protected"/>
     </module>
     <module name="NonEmptyAtclauseDescription">
       <property name="severity" value="warning"/>


### PR DESCRIPTION
Update the checkstyle config to be compatible with an upcoming breaking change in checkstyle. See https://github.com/checkstyle/checkstyle/pull/9277.

This should probably become a new branch, instead of being merged into the `checkstyle-7417` branch. But as a non-maintainer of the project I can't do this.